### PR TITLE
fix: set optional value for frameworkEnv, include schema/* in package

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -44,6 +44,7 @@
         "no-useless-constructor": 0, // in favor of @typescript-eslint/no-useless-constructor
         "no-warning-comments": 0,
         "operator-assignment": 0,
+        "semi": 2,
         // Node specific
         "no-process-exit": 0,
         "no-sync": 0,

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "main": "out/main/index.js",
     "files": [
         "out/main/**/*",
-        "out/bin/**/*"
+        "out/bin/**/*",
+        "schema/**/*"
     ],
     "bin": {
         "generate-openapi": "out/bin/generate-openapi.js",

--- a/src/main/env.ts
+++ b/src/main/env.ts
@@ -45,8 +45,8 @@ export class FrameworkEnv {
     HTTP_TIMEOUT = readNumber('HTTP_TIMEOUT', 300000);
     HTTP_SHUTDOWN_DELAY = readNumber('HTTP_SHUTDOWN_DELAY', 10000);
     API_JOB_TIMELINE_URL = readString('API_JOB_TIMELINE_URL', 'http://api-job-timeline');
-    API_JOB_TIMELINE_KEY = readString('API_JOB_TIMELINE_KEY');
-    AC_JWKS_URL = readString('AC_JWKS_URL', /* to be provided */);
+    API_JOB_TIMELINE_KEY = readString('API_JOB_TIMELINE_KEY', ''); // to avoid assert error when not used
+    AC_JWKS_URL = readString('AC_JWKS_URL', ''); // set default once available
     AC_SIGNING_KEY_ALGORITHM = readString('SIGNING_KEY_ALGORITHM', 'HS256');
     // temporary config for new auth compatibility
     AC_AUTH_HEADER_NAME = readString('AC_AUTH_HEADER_NAME', 'authorization-hs256');

--- a/src/main/jwt.ts
+++ b/src/main/jwt.ts
@@ -23,8 +23,8 @@ export class AutomationCloudJwt extends Jwt {
         if (!url || !algorithm) {
             throw new Exception({
                 name: 'ConfigurationError',
-                message: 'AC_JWKS_URL and AC_SIGNING_KEY_ALGORITHM is required for AutomationCloudJwt service',
-            })
+                message: 'Check Environment: AC_JWKS_URL, AC_SIGNING_KEY_ALGORITHM',
+            });
         }
 
         this.client = new JwksClient({

--- a/src/main/services/auth.ts
+++ b/src/main/services/auth.ts
@@ -17,8 +17,10 @@ export abstract class AuthService {
 
 @injectable()
 export class AuthServiceMock extends AuthService {
+    protected organisationId: string | null = null;
     async authorize(_ctx: Koa.Context) {}
-    getOrganisationId() { return null; }
+    getOrganisationId() { return this.organisationId; }
+    setOrganisationId(id: string) { this.organisationId = id }
 }
 
 @injectable()
@@ -32,7 +34,7 @@ export class AutomationCloudAuthService extends AuthService {
         @inject(Jwt)
         protected jwt: Jwt,
         @inject(FrameworkEnv)
-        protected env: FrameworkEnv
+        protected env: FrameworkEnv,
     ) {
         super();
         const baseUrl = this.env.API_AUTH_URL;

--- a/src/main/services/auth.ts
+++ b/src/main/services/auth.ts
@@ -20,7 +20,7 @@ export class AuthServiceMock extends AuthService {
     protected organisationId: string | null = null;
     async authorize(_ctx: Koa.Context) {}
     getOrganisationId() { return this.organisationId; }
-    setOrganisationId(id: string) { this.organisationId = id }
+    setOrganisationId(id: string) { this.organisationId = id; }
 }
 
 @injectable()

--- a/src/main/services/job-timeline.ts
+++ b/src/main/services/job-timeline.ts
@@ -68,7 +68,7 @@ export class ApiJobTimelineService extends JobTimelineService {
         if (!baseUrl || !authKey) {
             throw new Exception({
                 name: 'ConfigurationError',
-                message: 'Check Environment: API_JOB_TIMELINE_URL, API_JOB_TIMELINE_KEY'
+                message: 'Check Environment: API_JOB_TIMELINE_URL, API_JOB_TIMELINE_KEY',
             });
         }
 

--- a/src/main/services/job-timeline.ts
+++ b/src/main/services/job-timeline.ts
@@ -2,6 +2,7 @@ import { injectable, inject } from 'inversify';
 import { Logger } from '../logger';
 import { Request, BasicAuthAgent } from '@automationcloud/request';
 import { FrameworkEnv } from '../env';
+import { Exception } from '../exception';
 
 export interface JobTimelineEvent {
     namespace: string;
@@ -63,8 +64,15 @@ export class ApiJobTimelineService extends JobTimelineService {
     ) {
         super();
         const baseUrl = this.env.API_JOB_TIMELINE_URL;
-        // subject to change the auth afterwards?
         const authKey = this.env.API_JOB_TIMELINE_KEY;
+        if (!baseUrl || !authKey) {
+            throw new Exception({
+                name: 'ConfigurationError',
+                message: 'Check Environment: API_JOB_TIMELINE_URL, API_JOB_TIMELINE_KEY'
+            });
+        }
+
+        // subject to change the auth afterwards?
         const auth = new BasicAuthAgent({ username: authKey });
         this.request = new Request({ baseUrl, auth });
     }

--- a/src/test/specs/entity.test.ts
+++ b/src/test/specs/entity.test.ts
@@ -73,8 +73,9 @@ describe('Entity', () => {
                 capital: { name: '' },
                 cities: [ { name: 'city name' } ],
                 languages: []
-            })
-        })
+            });
+        });
+
     });
 
     describe('serialization', () => {

--- a/src/test/specs/services/auth.test.ts
+++ b/src/test/specs/services/auth.test.ts
@@ -24,7 +24,7 @@ describe('AutomationCloudAuthService', () => {
             requestSent = true;
             requestHeaders = options.headers;
             return Promise.resolve(new Response('{}'));
-        }
+        };
 
         container = new Container({ skipBaseClassChecks: true });
         container.bind(Logger).to(ConsoleLogger);
@@ -49,7 +49,7 @@ describe('AutomationCloudAuthService', () => {
                     authentication: {
                         mechanism: 'client_credentials'
                     },
-                }
+                };
             };
 
             const authHeader = container.get(FrameworkEnv).AC_AUTH_HEADER_NAME;
@@ -59,7 +59,7 @@ describe('AutomationCloudAuthService', () => {
 
             authService = container.get(AuthService) as AutomationCloudAuthService;
             await authService.authorize(ctx);
-        })
+        });
 
         it('gets organisation_id from token', async () => {
             const organisationId = authService.getOrganisationId();


### PR DESCRIPTION
- Some of the env (e.g. `API_JOB_TIMELINE_KEY`) doesn't have a default value, but when a user calls `assertEnv` in their own `Env` class, `FrameworkEnv`'s keys also validated, and it throws an error even though the app is not using `API_JOB_TIMELINE_KEY`. so I assigned empty string as a default value but added additional checking in each component's constructor
- added `schema/**/*`  to `files` property of package.json
- added `setOrganisationId` for AuthServiceMock 