### PR TITLE
feat: ask auth middleware when only legacy header present

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@automationcloud/request": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@automationcloud/request/-/request-2.0.1.tgz",
-      "integrity": "sha512-v8bIahON3VFSAi8HesMd4VD51awhVOkioXGMN99oM6WJ0G+/QjlGcY8PevABU0aV+oOpQ2F4WJXQV65r9Af1qw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@automationcloud/request/-/request-2.1.1.tgz",
+      "integrity": "sha512-w/Z79OG6ihYqtfd+TsXjkyGNHFanbXMN69ubC6pyAkFdLIf8Ug1jDI4Y+VtQamE1tOH3qH78eWL5n4rUMmdXzQ==",
       "requires": {
         "@types/node-fetch": "^2.5.3",
         "eventemitter3": "^4.0.7",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
         "typescript": "^3.9.5"
     },
     "dependencies": {
-        "@automationcloud/request": "^2.0.1",
+        "@automationcloud/request": "^2.1.1",
         "@koa/cors": "^3.0.0",
         "@types/dotenv": "^6.1.1",
         "@types/koa": "^2.0.52",

--- a/src/main/env.ts
+++ b/src/main/env.ts
@@ -47,11 +47,12 @@ export class FrameworkEnv {
     HTTP_SHUTDOWN_DELAY = readNumber('HTTP_SHUTDOWN_DELAY', 10000);
     API_JOB_TIMELINE_URL = readString('API_JOB_TIMELINE_URL', 'http://api-job-timeline');
     API_JOB_TIMELINE_KEY = readString('API_JOB_TIMELINE_KEY', ''); // to avoid assert error when not used
-    AC_JWKS_URL = readString('AC_JWKS_URL', 'http://hydra.authz.svc.cluster.local:4445/keys/internal');
-    AC_SIGNING_KEY_ALGORITHM = readString('SIGNING_KEY_ALGORITHM', 'HS256');
     // temporary config for new auth compatibility
     AC_AUTH_HEADER_NAME = readString('AC_AUTH_HEADER_NAME', 'x-ubio-auth');
+    AC_AUTH_MIDDLEWARE_URL = readString('AC_AUTH_MIDDLEWARE_URL', 'http://auth-middleware.authz.svc.cluster.local:8080');
+    AC_JWKS_URL = readString('AC_JWKS_URL', 'http://hydra.authz.svc.cluster.local:4445/keys/internal');
+    AC_SIGNING_KEY_ALGORITHM = readString('SIGNING_KEY_ALGORITHM', 'HS256');
     // deprecated, remove after migrating to new auth
     API_AUTH_URL = readString('API_AUTH_URL', 'http://api-router-internal');
-    API_AUTH_ENDPOINT = readString('API_AUTH_ENDPOINT', '/private/access');
+    API_AUTH_ENDPOINT = readString('API_AUTH_ENDPOINT', '/verify');
 }

--- a/src/main/env.ts
+++ b/src/main/env.ts
@@ -49,10 +49,7 @@ export class FrameworkEnv {
     API_JOB_TIMELINE_KEY = readString('API_JOB_TIMELINE_KEY', ''); // to avoid assert error when not used
     // temporary config for new auth compatibility
     AC_AUTH_HEADER_NAME = readString('AC_AUTH_HEADER_NAME', 'x-ubio-auth');
-    AC_AUTH_MIDDLEWARE_URL = readString('AC_AUTH_MIDDLEWARE_URL', 'http://auth-middleware.authz.svc.cluster.local:8080');
+    AC_AUTH_VERIFY_URL = readString('AC_AUTH_MIDDLEWARE_URL', 'http://auth-middleware.authz.svc.cluster.local:8080/verify');
     AC_JWKS_URL = readString('AC_JWKS_URL', 'http://hydra.authz.svc.cluster.local:4445/keys/internal');
     AC_SIGNING_KEY_ALGORITHM = readString('SIGNING_KEY_ALGORITHM', 'HS256');
-    // deprecated, remove after migrating to new auth
-    API_AUTH_URL = readString('API_AUTH_URL', 'http://api-router-internal');
-    API_AUTH_ENDPOINT = readString('API_AUTH_ENDPOINT', '/verify');
 }

--- a/src/main/services/request-auth.ts
+++ b/src/main/services/request-auth.ts
@@ -21,7 +21,7 @@ export class AutomationCloudAuthService extends RequestAuthService {
     clientRequest: Request;
     cacheTtl: number = 60000;
     // legacy forward header auth, deprecated
-    authorizedCache: Map<string, number> = new Map();
+    static authorizedCache: Map<string, { token: string, authorisedAt: number }> = new Map();
 
     constructor(
         @inject(JwtService)
@@ -32,7 +32,7 @@ export class AutomationCloudAuthService extends RequestAuthService {
         protected acContext: AutomationCloudContext,
     ) {
         super();
-        const baseUrl = this.env.API_AUTH_URL; // for forwardRequestHeader
+        const baseUrl = this.env.AC_AUTH_MIDDLEWARE_URL;
         this.clientRequest = new Request({
             baseUrl,
             retryAttempts: 3,
@@ -40,30 +40,37 @@ export class AutomationCloudAuthService extends RequestAuthService {
     }
 
     async check(ctx: Koa.Context) {
-        const authHeaderName = this.env.AC_AUTH_HEADER_NAME;
-        const newAuthHeader = ctx.req.headers[authHeaderName] as string;
-        if (newAuthHeader) {
+        const token = await this.getTokenFromHeader(ctx.req.headers as any);
+        if (token) {
             const organisationHeader = ctx.req.headers['x-ubio-organisation-id'] as string;
-            await this.handleNewAuth(newAuthHeader, organisationHeader);
-            return;
-        }
-        // Fallback to legacy header forwarding
-        const legacyAuthHeader = ctx.req.headers['authorization'];
-        if (legacyAuthHeader) {
-            await this.handleLegacyAuth(legacyAuthHeader);
+            await this.verifyAuth(token, organisationHeader);
         }
     }
 
-    protected async handleNewAuth(newAuthHeader: string, organisationHeader: string) {
-        const [prefix, token] = newAuthHeader.split(' ');
-        if (prefix !== 'Bearer' || !token) {
-            throw new Exception({
-                name: 'AuthenticationError',
-                message: `Incorrect authorization header (prefix=${prefix}, tokenExists=${!!token})`,
-                status: 401
-            });
+    protected async getTokenFromHeader(headers: { [name: string]: string | undefined }) {
+        const authHeaderName = this.env.AC_AUTH_HEADER_NAME;
+        const newAuthHeader = headers[authHeaderName];
+        if (newAuthHeader) {
+            const [prefix, token] = newAuthHeader.split(' ');
+            if (prefix !== 'Bearer' || !token) {
+                throw new Exception({
+                    name: 'AuthenticationError',
+                    message: `Incorrect authorization header (prefix=${prefix}, tokenExists=${!!token})`,
+                    status: 401
+                });
+            }
+            return token;
         }
+
+        const legacyHeader = headers['authorization'];
+        if (legacyHeader) {
+            return this.handleLegacyAuth(legacyHeader);
+        }
+    }
+
+    protected async verifyAuth(token: string, organisationHeader: string) {
         try {
+            // TODO: add cache
             const jwt = await this.jwt.decodeAndVerify(token);
             this.acContext.set({
                 authenticated: true,
@@ -80,18 +87,22 @@ export class AutomationCloudAuthService extends RequestAuthService {
         }
     }
 
-    protected async handleLegacyAuth(legacyAuthHeader: string) {
-        const authorizedAt = this.authorizedCache.get(legacyAuthHeader) || 0;
-        const invalid = authorizedAt + this.cacheTtl < Date.now();
-        if (invalid) {
+    protected async handleLegacyAuth(legacyAuthHeader: string): Promise<string> {
+        const { token: cachedToken, authorisedAt = 0 } = AutomationCloudAuthService.authorizedCache.get(legacyAuthHeader) || {};
+        const invalid = authorisedAt + this.cacheTtl < Date.now();
+        if (invalid || cachedToken == null) {
             const endpoint = this.env.API_AUTH_ENDPOINT;
             try {
-                await this.clientRequest.get(endpoint, {
+                const { token } = await this.clientRequest.get(endpoint, {
                     headers: {
                         authorization: legacyAuthHeader,
                     }
                 });
-                this.authorizedCache.set(legacyAuthHeader, Date.now());
+                AutomationCloudAuthService.authorizedCache.set(legacyAuthHeader, {
+                    token,
+                    authorisedAt: Date.now(),
+                });
+                return token;
             } catch (error) {
                 throw new Exception({
                     name: 'AuthenticationError',
@@ -101,11 +112,7 @@ export class AutomationCloudAuthService extends RequestAuthService {
                 });
             }
         }
-        // Auth successful
-        this.acContext.set({
-            authenticated: true,
-            organisationId: null,
-            serviceAccountId: null,
-        });
+
+        return cachedToken;
     }
 }


### PR DESCRIPTION
- it asks auth middleware to verify the auth header
- it gets the jwt token as a successful response
- it decodes and verifies as same way as for new auth header(token from `x-ubio-auth`)