### PR TITLE
Fix router params schema validation

### DIFF
--- a/src/main/router.ts
+++ b/src/main/router.ts
@@ -1,4 +1,5 @@
 import Ajv, { ValidateFunction as AjvValidateFunction } from 'ajv';
+import addFormats from 'ajv-formats';
 import escapeRegexp from 'escape-string-regexp';
 import { inject, injectable } from 'inversify';
 import * as koa from 'koa';
@@ -20,6 +21,7 @@ const ajv = new Ajv({
     useDefaults: true,
     removeAdditional: true,
 });
+addFormats(ajv);
 
 export function Get(spec: RouteSpec = {}) {
     return routeDecorator('get', spec);

--- a/src/main/router.ts
+++ b/src/main/router.ts
@@ -20,6 +20,7 @@ const ajv = new Ajv({
     coerceTypes: 'array',
     useDefaults: true,
     removeAdditional: true,
+    keywords: ['optional'],
 });
 addFormats(ajv);
 

--- a/src/test/routes/foo.ts
+++ b/src/test/routes/foo.ts
@@ -30,7 +30,7 @@ export class FooRouter extends Router {
         requestBodySchema: {
             type: 'object',
             properties: {
-                fooId: { type: 'string', minLength: 1 }
+                fooId: { type: 'string', minLength: 1, format: 'uuid' },
             },
             required: ['fooId']
         },

--- a/src/test/specs/router.test.ts
+++ b/src/test/specs/router.test.ts
@@ -158,14 +158,15 @@ describe('Router', () => {
         });
 
         it('POST /foo', async () => {
+            const fooId = '00000000-0000-0000-0000-000000000000';
             const request = supertest(app.httpServer.callback());
-            const res = await request.post('/foo')
-                .send({ fooId: 'blah' });
+            const res = await request.post('/foo').send({ fooId });
+
             assert.strictEqual(res.status, 201);
             assert.strictEqual(res.header['foo-before-all'], 'true');
             assert(res.header['bar-before-all'] == null);
             assert(res.header['foo-before-get-one'] == null);
-            assert.deepStrictEqual(res.body, { fooId: 'blah' });
+            assert.deepStrictEqual(res.body, { fooId });
         });
 
         it('POST /foo with missing params', async () => {
@@ -182,7 +183,7 @@ describe('Router', () => {
         it('POST /foo with incorrect params', async () => {
             const request = supertest(app.httpServer.callback());
             const res = await request.post('/foo')
-                .send({ fooId: '' });
+                .send({ fooId: 'blah' });
             assert.strictEqual(res.status, 400);
             assert.strictEqual(res.header['foo-before-all'], 'true');
             assert(res.header['bar-before-all'] == null);


### PR DESCRIPTION
To [use latest node-framework in hotelier](https://github.com/ubio/adapter-google-hotelier/pull/69) these fixes needed:
- it's not rare then we want to validate parameter format (`uuid`, `date`, etc)
- preprocessed schemas may have `optional` parameter

Other observations:
- we still have `required` for `QueryParam`, may be we should try to unify DSL for schema definitions
- a bit strange to not see warning on `@QueryParam('nights', { schema: { type: 'integer', min: 1 } })`  (should be `minimum`)
- `example` keyword considered invalid now 