### PR TITLE
feat: introduce AcActor in auth provider

### DIFF
--- a/src/main/ac-auth.ts
+++ b/src/main/ac-auth.ts
@@ -2,14 +2,34 @@ import { ClientError } from './exception';
 
 export interface AcAuthSpec {
     authenticated: boolean;
-    organisationId: string | null;
-    serviceAccountId: string | null;
+    organisationId?: string;
+    serviceAccountId?: string;
+    serviceAccountName?: string;
+    userId?: string;
+    userName?: string;
+    clientId?: string;
+    clientName?: string;
+    endUserId?: string;
 }
 
-export class AcAuth {
-    protected authenticated: boolean = false;
-    protected organisationId: string | null = null;
-    protected serviceAccountId: string | null = null;
+type Role = 'ServiceAccount' | 'User' | 'Client' | 'EndUser';
+interface Actor {
+    role: Role;
+    id: string;
+    name?: string;
+}
+
+
+export class AcAuth implements AcAuthSpec{
+    authenticated: boolean = false;
+    organisationId?: string;
+    serviceAccountId?: string;
+    serviceAccountName?: string;
+    userId?: string;
+    userName?: string;
+    clientId?: string;
+    clientName?: string;
+    endUserId?: string;
 
     constructor(spec: Partial<AcAuthSpec> = {}) {
         Object.assign(this, spec);
@@ -26,7 +46,7 @@ export class AcAuth {
     }
 
     getOrganisationId(): string | null {
-        return this.organisationId;
+        return this.organisationId ?? null;
     }
 
     requireOrganisationId(): string {
@@ -36,10 +56,16 @@ export class AcAuth {
         return this.organisationId;
     }
 
+    /**
+     * @deprecated use serviceAccountId instead, or use getActor()
+     */
     getServiceAccountId(): string | null {
-        return this.serviceAccountId;
+        return this.serviceAccountId ?? null;
     }
 
+    /**
+     * @deprecated use getActor()
+     */
     requireServiceAccountId(): string {
         if (!this.serviceAccountId) {
             throw new AccessForbidden('serviceAccountId is required');
@@ -47,6 +73,53 @@ export class AcAuth {
         return this.serviceAccountId;
     }
 
+    requireActor(roles: Role[] = ['ServiceAccount', 'User', 'Client', 'EndUser']) {
+        const actor = this.getActor();
+        if (!actor || !roles.includes(actor.role)) {
+            throw new AccessForbidden('Insufficient peremission');
+        }
+
+        return actor;
+    }
+
+    getActor(): Actor | null {
+        if (this.serviceAccountId) {
+            return {
+                role: 'ServiceAccount',
+                id: this.serviceAccountId,
+                name: this.serviceAccountName,
+            }
+        }
+
+        if (this.userId) {
+            return {
+                role: 'User',
+                id: this.userId,
+                name: this.userName,
+            };
+        }
+
+        if (this.clientId) {
+            return {
+                role: 'Client',
+                id: this.clientId,
+                name: this.clientName,
+            }
+        }
+
+        if (this.endUserId) {
+            return {
+                role: 'EndUser',
+                id: this.endUserId,
+            };
+        }
+
+        return null;
+    }
+
+    getRole(): Role | null {
+        return this.getActor()?.role ?? null
+    }
 }
 
 export class AuthenticationError extends ClientError {

--- a/src/main/ac-auth.ts
+++ b/src/main/ac-auth.ts
@@ -45,7 +45,7 @@ export interface AcJobAccessToken {
     type: 'JobAccessToken';
     jobId: string;
     organisationId: string;
-    // clientId: string;
+    clientId: string;
 }
 
 export class AcAuth {
@@ -184,11 +184,12 @@ export class AcAuth {
     }
 
     getJobAccessToken(): AcJobAccessToken | null {
-        const { job_id, organisation_id } = this.data;
-        if (job_id && organisation_id) {
+        const { job_id, client_id, organisation_id } = this.data;
+        if (job_id && client_id && organisation_id) {
             return {
                 type: 'JobAccessToken',
                 jobId: job_id,
+                clientId: client_id,
                 organisationId: organisation_id,
             };
         }

--- a/src/main/ac-auth.ts
+++ b/src/main/ac-auth.ts
@@ -70,6 +70,26 @@ export class AcAuth {
         return this.data.organisation_id;
     }
 
+    /**
+     *
+     * @deprecated - use getServiceAccount() instead
+     */
+    getServiceAccountId(): string | null {
+        return this.data.service_account_id ?? null;
+    }
+
+    /**
+     *
+     * @deprecated - use requireAuthorisedActor('ServiceAccount') or getServiceAccount() instead
+     */
+    requireServiceAccountId(): string {
+        const serviceAccountId = this.data.service_account_id ?? null;
+        if (!serviceAccountId) {
+            throw new AccessForbidden('serviceAccountId is required');
+        }
+
+        return serviceAccountId;
+    }
 
     requireAuthorisedActor(roles: AcRole[] = ['ServiceAccount', 'User', 'Client', 'JobAccessToken']) {
         const actor = this.getAuthorisedActor(roles);

--- a/src/main/ac-auth.ts
+++ b/src/main/ac-auth.ts
@@ -1,9 +1,11 @@
+/* eslint-disable camelcase */
+
 import { ClientError } from './exception';
 
 export interface AcAuthSpec {
     authenticated: boolean;
-    data: AcJwtContext,
-};
+    data: AcJwtContext;
+}
 
 export interface AcJwtContext {
     organisation_id?: string;
@@ -23,22 +25,27 @@ export interface AcServiceAccount {
     type: 'ServiceAccount';
     id: string;
     name: string;
+    organisationId?: string;
 }
 
 export interface AcUser {
     type: 'User';
     id: string;
     name: string;
+    organisationId: string;
 }
 export interface AcClient {
     type: 'Client';
     id: string;
     name: string;
+    organisationId: string;
 }
 
 export interface AcJobAccessToken {
     type: 'JobAccessToken';
-    job_id: string;
+    jobId: string;
+    organisationId: string;
+    // clientId: string;
 }
 
 export class AcAuth {
@@ -96,7 +103,7 @@ export class AcAuth {
     requireAuthorisedActor(roles: AcRole[] = ['ServiceAccount', 'User', 'Client', 'JobAccessToken']) {
         const actor = this.getAuthorisedActor(roles);
         if (!actor) {
-            throw new AccessForbidden('Insufficient peremission');
+            throw new AccessForbidden('Insufficient permission');
         }
 
         return actor;
@@ -143,39 +150,46 @@ export class AcAuth {
                 type: 'ServiceAccount',
                 id: this.data.service_account_id,
                 name: this.data.service_account_name,
-            }
+                organisationId: this.data.organisation_id,
+            };
         }
         return null;
     }
 
     getUser(): AcUser | null {
-        if (this.data.user_id && this.data.user_name) {
+        const { user_id, user_name, organisation_id } = this.data;
+        if (user_id && user_name && organisation_id) {
             return {
                 type: 'User',
-                id: this.data.user_id,
-                name: this.data.user_name,
+                id: user_id,
+                name: user_name,
+                organisationId: organisation_id,
             };
         }
         return null;
     }
 
     getClient(): AcClient | null {
-        if (this.data.client_id && this.data.client_name) {
+        const { client_id, client_name, organisation_id } = this.data;
+        if (client_id && client_name && organisation_id) {
             return {
                 type: 'Client',
-                id: this.data.client_id,
-                name: this.data.client_name,
-            }
+                id: client_id,
+                name: client_name,
+                organisationId: organisation_id,
+            };
         }
 
         return null;
     }
 
     getJobAccessToken(): AcJobAccessToken | null {
-        if (this.data.job_id) {
+        const { job_id, organisation_id } = this.data;
+        if (job_id && organisation_id) {
             return {
                 type: 'JobAccessToken',
-                job_id: this.data.job_id,
+                jobId: job_id,
+                organisationId: organisation_id,
             };
         }
         return null;

--- a/src/main/ac-auth.ts
+++ b/src/main/ac-auth.ts
@@ -71,16 +71,14 @@ export class AcAuth {
     }
 
     /**
-     *
-     * @deprecated - use getServiceAccount() instead
+     * @deprecated use getServiceAccount() instead
      */
     getServiceAccountId(): string | null {
         return this.data.service_account_id ?? null;
     }
 
     /**
-     *
-     * @deprecated - use requireAuthorisedActor('ServiceAccount') or getServiceAccount() instead
+     * @deprecated use requireAuthorisedActor('ServiceAccount') or getServiceAccount() instead
      */
     requireServiceAccountId(): string {
         const serviceAccountId = this.data.service_account_id ?? null;
@@ -91,6 +89,10 @@ export class AcAuth {
         return serviceAccountId;
     }
 
+    /**
+     * @param roles list of permitted roles. default to all.
+     * @returns Authorised AcActor. Throws when authorised actor's role is not included in the list
+     */
     requireAuthorisedActor(roles: AcRole[] = ['ServiceAccount', 'User', 'Client', 'JobAccessToken']) {
         const actor = this.getAuthorisedActor(roles);
         if (!actor) {
@@ -100,6 +102,10 @@ export class AcAuth {
         return actor;
     }
 
+    /**
+     * @param roles List of permitted roles. default to all.
+     * @returns Authorised AcActor or null. Returns null when authorised actor's role is not included in the list
+     */
     getAuthorisedActor(roles: AcRole[] = ['ServiceAccount', 'User', 'Client', 'JobAccessToken']): AcActor | null {
         for (const role of roles) {
             const actor = this.getActorByRole(role);
@@ -110,6 +116,11 @@ export class AcAuth {
         return null;
     }
 
+    /**
+     *
+     * @param role role of authorised actor
+     * @returns AcActor or null. Returns null when not authorised or authorised user's role is different to given `role` param.
+     */
     getActorByRole(role: AcRole): AcActor | null {
         switch (role) {
             case 'ServiceAccount':
@@ -125,6 +136,7 @@ export class AcAuth {
         }
     }
 
+    // explicit methods for calling each role
     getServiceAccount(): AcServiceAccount | null {
         if (this.data.service_account_id && this.data.service_account_name) {
             return {

--- a/src/main/services/ac-auth-provider.ts
+++ b/src/main/services/ac-auth-provider.ts
@@ -47,19 +47,16 @@ export class DefaultAcAuthProvider {
     }
 
     protected async createAuthFromToken(token: string): Promise<AcAuth> {
-        const organisationIdHeader = this.ctx.req.headers['x-ubio-organisation-id'] as string;
+        const organisationIdHeader = this.ctx.req.headers['x-ubio-organisation-id'] as string | undefined;
         try {
-            const { context = {} } = await this.jwt.decodeAndVerify(token);
+            const payload = await this.jwt.decodeAndVerify(token);
+            const data = {
+                organisation_id: organisationIdHeader,
+                ...payload.context
+            }
             return new AcAuth({
                 authenticated: true,
-                organisationId: context.organisation_id ?? organisationIdHeader,
-                serviceAccountId: context.service_account_id,
-                serviceAccountName: context.service_account_name,
-                userId: context.user_id,
-                userName: context.user_name,
-                clientId: context.client_id,
-                clientName: context.client_name,
-                endUserId: context.end_user_id,
+                data
             });
         } catch (err) {
             this.logger.warn(`Authentication from token failed`, { details: err });

--- a/src/main/services/ac-auth-provider.ts
+++ b/src/main/services/ac-auth-provider.ts
@@ -53,7 +53,7 @@ export class DefaultAcAuthProvider {
             const data = {
                 organisation_id: organisationIdHeader,
                 ...payload.context
-            }
+            };
             return new AcAuth({
                 authenticated: true,
                 data

--- a/src/main/services/ac-auth-provider.ts
+++ b/src/main/services/ac-auth-provider.ts
@@ -56,7 +56,7 @@ export class DefaultAcAuthProvider {
             };
             return new AcAuth({
                 authenticated: true,
-                data
+                data,
             });
         } catch (err) {
             this.logger.warn(`Authentication from token failed`, { details: err });

--- a/src/main/services/ac-auth-provider.ts
+++ b/src/main/services/ac-auth-provider.ts
@@ -49,11 +49,17 @@ export class DefaultAcAuthProvider {
     protected async createAuthFromToken(token: string): Promise<AcAuth> {
         const organisationIdHeader = this.ctx.req.headers['x-ubio-organisation-id'] as string;
         try {
-            const jwt = await this.jwt.decodeAndVerify(token);
+            const { context = {} } = await this.jwt.decodeAndVerify(token);
             return new AcAuth({
                 authenticated: true,
-                organisationId: jwt.context?.organisation_id ?? organisationIdHeader ?? null,
-                serviceAccountId: jwt.context?.service_user_id ?? null,
+                organisationId: context.organisation_id ?? organisationIdHeader,
+                serviceAccountId: context.service_account_id,
+                serviceAccountName: context.service_account_name,
+                userId: context.user_id,
+                userName: context.user_name,
+                clientId: context.client_id,
+                clientName: context.client_name,
+                endUserId: context.end_user_id,
             });
         } catch (err) {
             this.logger.warn(`Authentication from token failed`, { details: err });

--- a/src/main/services/ac-auth-provider.ts
+++ b/src/main/services/ac-auth-provider.ts
@@ -55,8 +55,7 @@ export class DefaultAcAuthProvider {
                 ...payload.context
             };
             return new AcAuth({
-                authenticated: true,
-                data,
+                jwtContext: data,
             });
         } catch (err) {
             this.logger.warn(`Authentication from token failed`, { details: err });

--- a/src/main/services/ac-auth-provider.ts
+++ b/src/main/services/ac-auth-provider.ts
@@ -16,8 +16,8 @@ export abstract class AcAuthProvider {
 export class DefaultAcAuthProvider {
     clientRequest: Request;
 
-    static legacyCacheTtl: number = 60000;
-    static legacyTokensCache: Map<string, { token: string, authorisedAt: number }> = new Map();
+    static middlewareCacheTtl: number = 60000;
+    static middlewareTokensCache: Map<string, { token: string, authorisedAt: number }> = new Map();
 
     @config({ default: 'x-ubio-auth' }) AC_AUTH_HEADER_NAME!: string;
     @config({ default: 'http://auth-middleware.authz.svc.cluster.local:8080/verify' })
@@ -66,9 +66,9 @@ export class DefaultAcAuthProvider {
 
     protected async getToken(headers: { [name: string]: string | undefined }) {
         const authHeaderName = this.AC_AUTH_HEADER_NAME;
-        const newAuthHeader = headers[authHeaderName];
-        if (newAuthHeader) {
-            const [prefix, token] = newAuthHeader.split(' ');
+        const upstreamAuth = headers[authHeaderName];
+        if (upstreamAuth) {
+            const [prefix, token] = upstreamAuth.split(' ');
             if (prefix !== 'Bearer' || !token) {
                 this.logger.warn(`Incorrect authorization header`, {
                     details: { prefix, token }
@@ -77,30 +77,30 @@ export class DefaultAcAuthProvider {
             }
             return token;
         }
-        const legacyHeader = headers['authorization'];
-        if (legacyHeader) {
-            return this.getTokenFromLegacyAuth(legacyHeader);
+        const authorization = headers['authorization'];
+        if (authorization) {
+            return this.getTokenFromAuthMiddleware(authorization);
         }
     }
 
-    protected async getTokenFromLegacyAuth(legacyAuthHeader: string): Promise<string> {
-        const cached = DefaultAcAuthProvider.legacyTokensCache.get(legacyAuthHeader) || { authorisedAt: 0, token: '' };
-        const invalid = cached.authorisedAt + DefaultAcAuthProvider.legacyCacheTtl < Date.now();
+    protected async getTokenFromAuthMiddleware(authorization: string): Promise<string> {
+        const cached = DefaultAcAuthProvider.middlewareTokensCache.get(authorization) || { authorisedAt: 0, token: '' };
+        const invalid = cached.authorisedAt + DefaultAcAuthProvider.middlewareCacheTtl < Date.now();
         if (invalid) {
             try {
                 const url = this.AC_AUTH_VERIFY_URL;
                 const { token } = await this.clientRequest.get(url, {
                     headers: {
-                        authorization: legacyAuthHeader,
+                        authorization: authorization,
                     }
                 });
-                DefaultAcAuthProvider.legacyTokensCache.set(legacyAuthHeader, {
+                DefaultAcAuthProvider.middlewareTokensCache.set(authorization, {
                     token,
                     authorisedAt: Date.now(),
                 });
                 return token;
             } catch (error) {
-                this.logger.warn('Legacy authentication failed', { ...error });
+                this.logger.warn('AuthMiddleware authentication failed', { ...error });
                 throw new AuthenticationError();
             }
         }

--- a/src/main/services/ac-auth-provider.ts
+++ b/src/main/services/ac-auth-provider.ts
@@ -97,6 +97,7 @@ export class DefaultAcAuthProvider {
                     token,
                     authorisedAt: Date.now(),
                 });
+                this.pruneCache();
                 return token;
             } catch (error) {
                 this.logger.warn('AuthMiddleware authentication failed', { ...error });
@@ -104,5 +105,15 @@ export class DefaultAcAuthProvider {
             }
         }
         return cached.token;
+    }
+
+    pruneCache() {
+        const now = Date.now();
+        const entries = DefaultAcAuthProvider.middlewareTokensCache.entries();
+        for (const [k, v] of entries) {
+            if (v.authorisedAt + DefaultAcAuthProvider.middlewareCacheTtl < now) {
+                DefaultAcAuthProvider.middlewareTokensCache.delete(k);
+            }
+        }
     }
 }

--- a/src/main/services/ac-auth-provider.ts
+++ b/src/main/services/ac-auth-provider.ts
@@ -89,11 +89,10 @@ export class DefaultAcAuthProvider {
         if (invalid) {
             try {
                 const url = this.AC_AUTH_VERIFY_URL;
-                const { token } = await this.clientRequest.get(url, {
-                    headers: {
-                        authorization: authorization,
-                    }
-                });
+                const options = {
+                    headers: { authorization },
+                };
+                const { token } = await this.clientRequest.get(url, options);
                 DefaultAcAuthProvider.middlewareTokensCache.set(authorization, {
                     token,
                     authorisedAt: Date.now(),

--- a/src/test/integration/ac-auth-mocking.test.ts
+++ b/src/test/integration/ac-auth-mocking.test.ts
@@ -28,8 +28,11 @@ describe('Mocking AcAuth', () => {
         async provide() {
             return new AcAuth({
                 authenticated: true,
-                organisationId: 'foo',
-                serviceAccountId: 'bar',
+                data: {
+                    organisation_id: 'foo',
+                    service_account_id: 'service-account-worker',
+                    service_account_name: 'Bot',
+                }
             });
         }
     });
@@ -41,10 +44,13 @@ describe('Mocking AcAuth', () => {
     it('returns mocked data', async () => {
         const request = supertest(app.httpServer.callback());
         const res = await request.get('/foo');
-        assert.deepEqual(res.body, {
+        assert.deepStrictEqual(res.body, {
             authenticated: true,
-            organisationId: 'foo',
-            serviceAccountId: 'bar',
+            data: {
+                organisation_id: 'foo',
+                service_account_id: 'service-account-worker',
+                service_account_name: 'Bot',
+            }
         });
     });
 

--- a/src/test/integration/ac-auth-mocking.test.ts
+++ b/src/test/integration/ac-auth-mocking.test.ts
@@ -27,8 +27,7 @@ describe('Mocking AcAuth', () => {
     app.container.rebind(AcAuthProvider).toConstantValue({
         async provide() {
             return new AcAuth({
-                authenticated: true,
-                data: {
+                jwtContext: {
                     organisation_id: 'foo',
                     service_account_id: 'service-account-worker',
                     service_account_name: 'Bot',
@@ -45,12 +44,6 @@ describe('Mocking AcAuth', () => {
         const request = supertest(app.httpServer.callback());
         const res = await request.get('/foo');
         assert.deepStrictEqual(res.body, {
-            authenticated: true,
-            data: {
-                organisation_id: 'foo',
-                service_account_id: 'service-account-worker',
-                service_account_name: 'Bot',
-            },
             actor: {
                 type: 'ServiceAccount',
                 id: 'service-account-worker',

--- a/src/test/integration/ac-auth-mocking.test.ts
+++ b/src/test/integration/ac-auth-mocking.test.ts
@@ -50,8 +50,13 @@ describe('Mocking AcAuth', () => {
                 organisation_id: 'foo',
                 service_account_id: 'service-account-worker',
                 service_account_name: 'Bot',
+            },
+            actor: {
+                type: 'ServiceAccount',
+                id: 'service-account-worker',
+                name: 'Bot',
+                organisationId: 'foo',
             }
         });
     });
-
 });

--- a/src/test/specs/services/ac-auth.test.ts
+++ b/src/test/specs/services/ac-auth.test.ts
@@ -46,17 +46,17 @@ describe('AcAuthProvider', () => {
     afterEach(() => {
         jwt = {};
         headers = {};
-        DefaultAcAuthProvider.legacyTokensCache = new Map();
+        DefaultAcAuthProvider.middlewareTokensCache = new Map();
     });
 
-    describe('new auth header exists', () => {
+    describe('x-ubio-auth header exists', () => {
 
         beforeEach(() => {
             const authHeader = container.get(DefaultAcAuthProvider).AC_AUTH_HEADER_NAME;
             headers[authHeader] = 'Bearer jwt-token-here';
         });
 
-        it('does not send request to auth-middleware', async () => {
+        it('does not send request to authMiddleware', async () => {
             await authProvider.provide();
             assert.strictEqual(fetchMock.spy.called, false);
         });
@@ -112,7 +112,7 @@ describe('AcAuthProvider', () => {
 
     });
 
-    describe('legacy auth', () => {
+    describe('middleware auth', () => {
         it('sends a request to auth middleware with Authorization header', async () => {
             headers['authorization'] = 'AUTH';
             assert.strictEqual(fetchMock.spy.called, false);
@@ -126,8 +126,8 @@ describe('AcAuthProvider', () => {
         it('does not send request if Authorization is cached', async () => {
             const ttl = 60000;
             const margin = 1000;
-            DefaultAcAuthProvider.legacyCacheTtl = ttl;
-            DefaultAcAuthProvider.legacyTokensCache.set('AUTH', {
+            DefaultAcAuthProvider.middlewareCacheTtl = ttl;
+            DefaultAcAuthProvider.middlewareTokensCache.set('AUTH', {
                 token: 'jwt-token-here',
                 authorisedAt: Date.now() - ttl + margin
             });
@@ -141,8 +141,8 @@ describe('AcAuthProvider', () => {
         it('sends request if cache has expired', async () => {
             const ttl = 60000;
             const margin = 1000;
-            DefaultAcAuthProvider.legacyCacheTtl = ttl;
-            DefaultAcAuthProvider.legacyTokensCache.set('AUTH', { token: 'jwt-token-here', authorisedAt: Date.now() - ttl - margin });
+            DefaultAcAuthProvider.middlewareCacheTtl = ttl;
+            DefaultAcAuthProvider.middlewareTokensCache.set('AUTH', { token: 'jwt-token-here', authorisedAt: Date.now() - ttl - margin });
             headers['authorization'] = 'AUTH';
             assert.strictEqual(fetchMock.spy.called, false);
             const auth = await authProvider.provide();


### PR DESCRIPTION
This PR introduces `AcActor` entity in `DefaultAcAuthProvider`. Now Applications can identify the authenticated user's role(e.g. `ServiceAccount`).
