### PR TITLE
fix: schema decode for top level arrays

### DIFF
--- a/src/main/schema.ts
+++ b/src/main/schema.ts
@@ -50,7 +50,7 @@ export class Schema<T> {
 
     construct(obj: any): unknown {
         // Defaults are only applied to objects
-        if (obj && typeof obj === 'object') {
+        if (obj && typeof obj === 'object' && this.schema.type === 'object') {
             const defaults = typeof this.defaults === 'function' ? this.defaults() : this.defaults;
             return { ...defaults, ...obj };
         }

--- a/src/test/specs/schema.test.ts
+++ b/src/test/specs/schema.test.ts
@@ -20,6 +20,13 @@ const Person = new Schema<Person>({
     }
 });
 
+const People = new Schema<Person[]>({
+    schema: {
+        type: 'array',
+        items: Person.schema
+    }
+});
+
 interface Book {
     id: string;
     title: string;
@@ -130,6 +137,14 @@ describe('Schema', () => {
             } catch (err) {
                 assert.strictEqual(err.name, 'ValidationError');
             }
+        });
+
+        it('works with top level arrays', () => {
+            const nobody = People.decode([]);
+            const people = People.decode([{ name: 'Ron', gender: null }]);
+            assert(Array.isArray(nobody));
+            assert.strictEqual(people[0].name, 'Ron');
+            assert.strictEqual(people[0].gender, null);
         });
     });
 });


### PR DESCRIPTION
at the moment `.decode([anything])` fails b/c `construct` converts `[anything]` to `{ 0: anything }`