### PR TITLE
feat: add BypassAcAuthProvider

### DIFF
--- a/src/main/services/ac-auth-provider.ts
+++ b/src/main/services/ac-auth-provider.ts
@@ -13,7 +13,7 @@ export abstract class AcAuthProvider {
 }
 
 @injectable()
-export class DefaultAcAuthProvider {
+export class DefaultAcAuthProvider extends AcAuthProvider {
     clientRequest: Request;
 
     static middlewareCacheTtl: number = 60000;
@@ -33,6 +33,7 @@ export class DefaultAcAuthProvider {
         @inject('KoaContext')
         protected ctx: Koa.Context,
     ) {
+        super();
         this.clientRequest = new Request({
             retryAttempts: 3,
         });
@@ -114,5 +115,12 @@ export class DefaultAcAuthProvider {
                 DefaultAcAuthProvider.middlewareTokensCache.delete(k);
             }
         }
+    }
+}
+
+@injectable()
+export class BypassAcAuthProvider extends AcAuthProvider {
+    async provide() {
+        return new AcAuth();
     }
 }

--- a/src/test/routes/access.ts
+++ b/src/test/routes/access.ts
@@ -1,0 +1,34 @@
+import { inject, injectable } from 'inversify';
+
+import { AcAuth, Get, Router } from '../../main';
+
+@injectable()
+export class AccessRouter extends Router {
+    constructor(
+        @inject(AcAuth)
+        protected auth: AcAuth,
+    ) {
+        super();
+    }
+
+    @Get({
+        path: '/public',
+        responses: {
+            200: { schema: { type: 'array', items: { type: 'string' } } }
+        }
+    })
+    async public() {
+        return ['no', 'secret', 'here'];
+    }
+
+    @Get({
+        path: '/secret',
+        responses: {
+            200: { schema: { type: 'array', items: { type: 'string' } } }
+        }
+    })
+    async secrets() {
+        this.auth.checkAuthenticated();
+        return ['open', 'sesame'];
+    }
+}

--- a/src/test/specs/services/bypass-auth-provider.test.ts
+++ b/src/test/specs/services/bypass-auth-provider.test.ts
@@ -1,0 +1,88 @@
+import assert from 'assert';
+import supertest from 'supertest';
+
+import {
+    AcAuthProvider,
+    Application,
+    BypassAcAuthProvider,
+    Router,
+} from '../../../main';
+import { AccessRouter } from '../../routes/access';
+
+describe('BypassAuthProvider', () => {
+    class App extends Application {
+        constructor() {
+            super();
+            this.container.bind(Router).to(AccessRouter);
+            this.container.rebind(AcAuthProvider).to(BypassAcAuthProvider);
+        }
+        async beforeStart() {
+            await this.httpServer.startServer();
+        }
+        async afterStop() {
+            await this.httpServer.stopServer();
+        }
+    }
+
+    const app = new App();
+    beforeEach(() => app.start());
+    afterEach(() => app.stop());
+
+    context('route do not require authentication', () => {
+        context('auth headers not provided', () => {
+            it('does not return 401 when Authorization not provided', async () => {
+                const request = supertest(app.httpServer.callback());
+                const res = await request.get('/public');
+                assert.ok(res.ok);
+                assert.strictEqual(res.status, 200);
+            });
+
+            it('does not return 401 when x-ubio-auth not provided', async () => {
+                const request = supertest(app.httpServer.callback());
+                const res = await request.get('/public');
+                assert.ok(res.ok);
+                assert.strictEqual(res.status, 200);
+            });
+        });
+
+        context('auth headers provided', () => {
+            it('does not return 401 when Authorization found (does not try to authenticate)', async () => {
+                const request = supertest(app.httpServer.callback());
+                const res = await request
+                    .get('/public')
+                    .set('Authorization', 'Bearer some-token');
+                assert.ok(res.ok);
+                assert.strictEqual(res.status, 200);
+            });
+
+            it('does not return 401 when x-ubio-auth header found (does not try to authenticate)', async () => {
+                const request = supertest(app.httpServer.callback());
+                const res = await request
+                    .get('/public')
+                    .set('x-ubio-auth', 'Bearer some-token');
+                assert.ok(res.ok);
+                assert.strictEqual(res.status, 200);
+            });
+        });
+    });
+
+    context('route requires authentication (checkAuthenticated is called)', () => {
+        it('returns 401 when auth headers not provided', async () => {
+            const request = supertest(app.httpServer.callback());
+            const res = await request.get('/secret');
+
+            assert.ok(!res.ok);
+            assert.strictEqual(res.status, 401);
+        });
+
+        it('returns 401 when auth headers provided', async () => {
+            const request = supertest(app.httpServer.callback());
+            const res = await request
+                .get('/secret')
+                .set('Authorization', 'Bearer some-token')
+                .set('x-ubio-auth', 'Bearer some-token');
+            assert.ok(!res.ok);
+            assert.strictEqual(res.status, 401);
+        });
+    });
+});


### PR DESCRIPTION
BypassAcAuthProvider can be used when the Application no not require any authentication for the requests