### PR TITLE
Handling errors issue propsal

### DIFF
--- a/src/main/metrics/push-gateway.ts
+++ b/src/main/metrics/push-gateway.ts
@@ -44,7 +44,9 @@ export class MetricsPushGateway {
                 body: payload + '\n',
             });
         } catch (error) {
-            const response = await error.response.text();
+            let response = error.response ? await error.response.text() : error.message;
+            if (!response || response.length === 0) { response = 'No response information found'; }
+
             this.logger.error('Push gateway failed', {
                 details: error,
                 response,


### PR DESCRIPTION
I've faced an issue, when I can't push my metrics because of some error. Sadly I can't see an error. After a short investigation I've found a possible problem. 

Original response on `MetricsPushGateway.pushAll` method called:

`{"message":"error: FetchError: request to http://some-address-here failed, reason: getaddrinfo ENOTFOUND domain-name-without-protocol-here","severity":"INFO","timestamp":"2021-11-16T17:21:15987089077Z"}`

May be I've missed something or may be it should be updated somewhere else. So, just a proposal in