### PR TITLE
Add HTTP_TEXT_LIMIT env variable

### DIFF
--- a/src/main/http.ts
+++ b/src/main/http.ts
@@ -31,6 +31,7 @@ export class HttpServer extends Koa {
 
     @config({ default: 8080 }) PORT!: number;
     @config({ default: '5mb' }) HTTP_JSON_LIMIT!: string;
+    @config({ default: '10mb' }) HTTP_TEXT_LIMIT!: string;
     @config({ default: '1mb' }) HTTP_FORM_LIMIT!: string;
     @config({ default: 50 * 1024 * 1024 }) HTTP_MAX_FILE_SIZE_BYTES!: number;
     @config({ default: false }) HTTP_INCLUDE_UNPARSED_BODY!: boolean;
@@ -68,6 +69,7 @@ export class HttpServer extends Koa {
                 urlencoded: true,
                 multipart: true,
                 jsonLimit: this.HTTP_JSON_LIMIT,
+                textLimit: this.HTTP_TEXT_LIMIT,
                 formLimit: this.HTTP_FORM_LIMIT,
                 formidable: {
                     maxFileSize: this.HTTP_MAX_FILE_SIZE_BYTES,


### PR DESCRIPTION
This should allow uploads of CSV files bigger than 56KiB.

part of https://github.com/ubio/squad-smart-feed/issues/208
