### PR TITLE
Remove timestamp from a gauge metric to prevent it's staleness in Grafana

### DIFF
--- a/src/main/metrics/gauge.ts
+++ b/src/main/metrics/gauge.ts
@@ -13,7 +13,7 @@ export class GaugeMetric<L = any> extends Metric<L> {
                 this.getMetricLineName(datum.labels),
                 datum.value,
                 datum.timestamp,
-            ].join(' ');
+            ].filter(x => x != null).join(' ');
         }
     }
 

--- a/src/main/metrics/gauge.ts
+++ b/src/main/metrics/gauge.ts
@@ -21,7 +21,7 @@ export class GaugeMetric<L = any> extends Metric<L> {
         return this.data.get(this.createMetricLabelsKey(labels));
     }
 
-    set(value: number, labels: Partial<L> = {}, timestamp: number = Date.now()) {
+    set(value: number, labels: Partial<L> = {}, timestamp?: number) {
         const key = this.createMetricLabelsKey(labels);
         const datum = this.data.get(key);
         if (datum) {


### PR DESCRIPTION
https://github.com/ubio/squad-smart-feed/issues/296
https://github.com/ubio/smart-feed/pull/228

The intention is to remove gaps in the gauge chart if we update the gauge rarely (a period between updates is >5 min):
<img width="1379" alt="Screenshot 2022-05-13 at 13 48 29" src="https://user-images.githubusercontent.com/18077528/168268626-489a14de-6ecb-4423-b919-4aca2babe20b.png">

Similar to https://github.com/ubio/node-framework/pull/18