### PR TITLE
chore: make AcAuthProvider global

### DIFF
--- a/src/main/application.ts
+++ b/src/main/application.ts
@@ -41,6 +41,7 @@ export class Application {
         mesh.service(Config, ProcessEnvConfig);
         mesh.service(HttpServer);
         mesh.service(AutomationCloudJwtService);
+        mesh.service(AcAuthProvider, DefaultAcAuthProvider);
         mesh.alias(JwtService, AutomationCloudJwtService);
         mesh.constant('GlobalMetrics', getGlobalMetrics());
         mesh.service(MetricsPushGateway);
@@ -52,7 +53,6 @@ export class Application {
         mesh.parent = this.mesh;
         mesh.service(Logger, HttpRequestLogger);
         mesh.service(MetricsRouter);
-        mesh.service(AcAuthProvider, DefaultAcAuthProvider);
         return mesh;
     }
 

--- a/src/main/http.ts
+++ b/src/main/http.ts
@@ -173,7 +173,7 @@ export class HttpServer extends Koa {
         return async (ctx: Koa.Context, next: Koa.Next) => {
             const mesh: Mesh = ctx.mesh;
             const provider = mesh.resolve(AcAuthProvider);
-            const acAuth = await provider.provide();
+            const acAuth = await provider.provide(ctx.headers);
             mesh.constant(AcAuth, acAuth);
             return next();
         };


### PR DESCRIPTION
This PR makes it significantly easier for apps to stub/mock/replace AcAuthProvider by dragging it out of session scope into global (where it can be easily overridden on App).

This is made possible by slightly changing the interface: now the caller needs to pass the headers (previously `provide` had zero arguments but instead was relying on session-scoped Koa context). In practice the applications are unlikely to rely on calling the method, so this change only affects framework's own tests (and even those are arguably a tad nicer), 