### PR TITLE
Update koa-compress to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
                 "jsonwebtoken": "^9.0.0",
                 "koa": "^2.11.0",
                 "koa-body": "^4.2.0",
-                "koa-compress": "^5.0.1",
+                "koa-compress": "^5.1.1",
                 "koa-conditional-get": "^3.0.0",
                 "koa-etag": "^4.0.0",
                 "mesh-ioc": "^3.2.0",
@@ -5622,26 +5622,17 @@
             "integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw=="
         },
         "node_modules/koa-compress": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/koa-compress/-/koa-compress-5.1.0.tgz",
-            "integrity": "sha512-G3Ppo9jrUwlchp6qdoRgQNMiGZtM0TAHkxRZQ7EoVvIG8E47J4nAsMJxXHAUQ+0oc7t0MDxSdONWTFcbzX7/Bg==",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/koa-compress/-/koa-compress-5.1.1.tgz",
+            "integrity": "sha512-UgMIN7ZoEP2DuoSQmD6CYvFSLt0NReGlc2qSY4bO4Oq0L56OiD9pDG41Kj/zFmVY/A3Wvmn4BqKcfq5H30LGIg==",
             "dependencies": {
-                "bytes": "^3.0.0",
-                "compressible": "^2.0.0",
-                "http-errors": "^1.8.0",
-                "koa-is-json": "^1.0.0",
-                "statuses": "^2.0.1"
+                "bytes": "^3.1.2",
+                "compressible": "^2.0.18",
+                "http-errors": "^1.8.1",
+                "koa-is-json": "^1.0.0"
             },
             "engines": {
-                "node": ">= 8.0.0"
-            }
-        },
-        "node_modules/koa-compress/node_modules/statuses": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-            "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-            "engines": {
-                "node": ">= 0.8"
+                "node": ">= 12"
             }
         },
         "node_modules/koa-conditional-get": {
@@ -12350,22 +12341,14 @@
             "integrity": "sha512-8ODW8TrDuMYvXRwra/Kh7/rJo9BtOfPc6qO8eAfC80CnCvSjSl0bkRM24X6/XBBEyj0v1nRUQ1LyOy3dbqOWXw=="
         },
         "koa-compress": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/koa-compress/-/koa-compress-5.1.0.tgz",
-            "integrity": "sha512-G3Ppo9jrUwlchp6qdoRgQNMiGZtM0TAHkxRZQ7EoVvIG8E47J4nAsMJxXHAUQ+0oc7t0MDxSdONWTFcbzX7/Bg==",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/koa-compress/-/koa-compress-5.1.1.tgz",
+            "integrity": "sha512-UgMIN7ZoEP2DuoSQmD6CYvFSLt0NReGlc2qSY4bO4Oq0L56OiD9pDG41Kj/zFmVY/A3Wvmn4BqKcfq5H30LGIg==",
             "requires": {
-                "bytes": "^3.0.0",
-                "compressible": "^2.0.0",
-                "http-errors": "^1.8.0",
-                "koa-is-json": "^1.0.0",
-                "statuses": "^2.0.1"
-            },
-            "dependencies": {
-                "statuses": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-                    "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
-                }
+                "bytes": "^3.1.2",
+                "compressible": "^2.0.18",
+                "http-errors": "^1.8.1",
+                "koa-is-json": "^1.0.0"
             }
         },
         "koa-conditional-get": {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
         "jsonwebtoken": "^9.0.0",
         "koa": "^2.11.0",
         "koa-body": "^4.2.0",
-        "koa-compress": "^5.0.1",
+        "koa-compress": "^5.1.1",
         "koa-conditional-get": "^3.0.0",
         "koa-etag": "^4.0.0",
         "mesh-ioc": "^3.2.0",


### PR DESCRIPTION
Earlier this year we have some issues with `br` compression algorithm. I was about to make it possible to configure compressing type via parameters, but it looks like we should have no issues using `br` now, since we move to a later node version.