### PR TITLE
remove deprecated useNewUrlParser and useUnifiedTopology

### DIFF
--- a/src/modules/mongodb.ts
+++ b/src/modules/mongodb.ts
@@ -1,13 +1,9 @@
 import { Logger } from '@nodescript/logger';
 import { config } from 'mesh-config';
 import { dep } from 'mesh-ioc';
-import { Db, MongoClient, MongoClientOptions } from 'mongodb';
+import { Db, MongoClient } from 'mongodb';
 
 import { getGlobalMetrics } from '../main/index.js';
-
-interface MongoClientOptionsExtended extends MongoClientOptions {
-    useUnifiedTopology: boolean;
-}
 
 export class MongoDb {
     client: MongoClient;
@@ -22,10 +18,8 @@ export class MongoDb {
 
     constructor() {
         this.client = new MongoClient(this.MONGO_URL, {
-            useNewUrlParser: true,
-            useUnifiedTopology: true,
             ignoreUndefined: true,
-        } as MongoClientOptionsExtended);
+        });
     }
 
     get db(): Db {


### PR DESCRIPTION
We're currently on Mongo version 6, where there is a deprecation warning for useNewUrlParser and useUnifiedTopology options, introduced with [PR](https://github.com/mongodb/node-mongodb-native/pull/3792).

> These options were removed in 4.0.0 but continued to be parsed and silently left unused. We have now added a deprecation warning through Node.js' [warning system](https://nodejs.org/api/process.html#event-warning) to prepare for finally removing these options in the next major release.